### PR TITLE
Fix the alignment; mode changes on right-click

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,3 +1,4 @@
+const Clutter = imports.gi.Clutter;
 const St = imports.gi.St;
 const Main = imports.ui.main;
 // const Tweener = imports.ui.tweener;
@@ -56,11 +57,13 @@ function init() {
 
     ioSpeedStaticIcon = new St.Icon({
         style_class: 'system-status-icon',
+        y_align: Clutter.ActorAlign.CENTER,
         gicon: Gio.icon_new_for_string('drive-harddisk-symbolic')
     });
 
     ioSpeed = new St.Label({
         text: '---',
+        y_align: Clutter.ActorAlign.CENTER,
         style_class: 'harddiskled-label'
     });
 
@@ -71,6 +74,7 @@ function init() {
 
     ioSpeedIcon = new St.Label({
         text: '',
+        y_align: Clutter.ActorAlign.CENTER,
         style_class: 'harddiskled-icon'
     });
 

--- a/extension.js
+++ b/extension.js
@@ -85,13 +85,16 @@ function init() {
     lastCount = 0;
 }
 
-function changeMode() {
-    mode++;
-    if (mode > 4) {
-        mode = 0;
+function changeMode(data, event) {
+    // React only to right-clicks.
+    if (event.get_button() == 3) {
+        mode++;
+        if (mode > 4) {
+            mode = 0;
+        }
+        settings.set_int('mode', mode);
+        parseStat(true);
     }
-    settings.set_int('mode', mode);
-    parseStat(true);
 }
 
 function parseStat(forceDot = false) {


### PR DESCRIPTION
I've fixed the alignment on gnome-shell 3.36. Now both the label and the small-dot are again align in the middle. However, the big-dot still looks a bit out-of-centre.

I've also slightly modified the click behaviour. Now only the right-click switches between the different modes; too many times I've clicked there by mistake :)