### PR TITLE
Reduce JS confusion on assignment in while()

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -106,7 +106,7 @@ function parseStat(forceDot = false) {
 
         let count = 0;
         let line;
-        while (line = dstream.read_line(null)) {
+        while ((line = dstream.read_line(null))) {
             line = String(line);
             let fields = line.split(/ +/);
             if (fields.length<=2) break;


### PR DESCRIPTION
Without this change, the JS runtime warns about a potential mistype
of an assignment vs equality check.

   JS WARNING: [.../harddiskled@bijidroid.gmail.com/extension.js 109]: test for equality (==) mistyped as assignment (=)?

The fix is easy, put the assigment inside its own set of () which is
parsed by JS before the boolean evaluation of 'line'.

Signed-off-by: David Sommerseth <dazo@eurephia.org>