### PR TITLE
Fix ByteArray warning, declare compatibility with GNOME Shell 42

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -25,6 +25,16 @@ let mode;
 let layoutManager;
 let ioSpeedStaticIcon;
 let ioSpeedIcon;
+let byteArrayToString;
+
+if (global.TextDecoder) {
+    // available in gjs >= 1.70 (GNOME Shell >= 42)
+    byteArrayToString = (new TextDecoder().decode);
+}
+else {
+    // gjs-specific
+    byteArrayToString = imports.byteArray.toString;
+}
 
 function init() {
     cur = 0;
@@ -48,8 +58,8 @@ function parseStat(forceDot = false) {
 
         let count = 0;
         let line;
-        while ((line = dstream.read_line(null))) {
-            line = String(line);
+        while (([line, len] = dstream.read_line(null)) != null && line != null) {
+            line = byteArrayToString(line);
             let fields = line.split(/ +/);
             if (fields.length<=2) break;
 

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
     "3.36",
     "3.38",
     "40",
-    "41"
+    "41",
+    "42"
   ], 
   "url": "https://github.com/biji/harddiskled", 
   "uuid": "harddiskled@bijidroid.gmail.com", 


### PR DESCRIPTION
* extension: Avoid deprecated conversion from Uint8Array to String
    
    Previously, this logged a warning:
    
        Some code called array.toString() on a Uint8Array instance.
        Previously this would have interpreted the bytes of the array
        as a string, but that is nonstandard. In the future this will
        return the bytes as comma-separated digits. For the time being,
        the old behavior has been preserved, but please fix your code
        anyway to explicitly call ByteArray.toString(array).
    
    The byteArray module mentioned in the warning is itself non-standard,
    and in gjs >= 1.70, there is a standard JavaScript replacement for it,
    the TextEncoder object. For details see
    <https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/1946>.

    Resolves: #14 

* metadata: Declare compatibility with GNOME Shell 42
    
    Bug-Debian: https://bugs.debian.org/1008535