### PR TITLE
Add Gnome 44 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,8 @@
     "40",
     "41",
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/biji/harddiskled",
   "uuid": "harddiskled@bijidroid.gmail.com",

--- a/metadata.json
+++ b/metadata.json
@@ -15,5 +15,5 @@
   ],
   "url": "https://github.com/biji/harddiskled",
   "uuid": "harddiskled@bijidroid.gmail.com",
-  "version": 33
+  "version": 34
 }


### PR DESCRIPTION
Harddisk LED works well in Gnome 44.