### PR TITLE
Refactor timeout handling for GNOME 45 compatibility

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -2,7 +2,7 @@ import { default as Clutter } from 'gi://Clutter';
 import { default as St } from 'gi://St';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import { default as Gio } from 'gi://Gio';
-const Mainloop = imports.mainloop; // still using legacy imports (GNOME Shell < 45), but no new method exists for this import!
+import GLib from 'gi://GLib';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 export default class HardDiskLEDExtension extends Extension {
@@ -201,11 +201,15 @@ export default class HardDiskLEDExtension extends Extension {
         this.button.set_child(this.layoutManager);
 
         Main.panel._rightBox.insert_child_at_index(this.button, 0);
-        this.timeout = Mainloop.timeout_add_seconds(this.refreshTime, this.parseStat.bind(this));
+        this.timeout = GLib.timeout_add(
+            GLib.PRIORITY_DEFAULT, 
+            this.refreshTime, 
+            () => this.parseStat(true)
+        );
     }
 
     disable() {
-        Mainloop.source_remove(this.timeout);
+        GLib.source_remove(this.timeout);
         this.timeout = null;
         Main.panel._rightBox.remove_child(this.button);
         this.button.destroy();

--- a/extension.js
+++ b/extension.js
@@ -6,7 +6,7 @@ import GLib from 'gi://GLib';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 export default class HardDiskLEDExtension extends Extension {
-    refreshTime = 2.0;
+    refreshTime = 2.0*200;
 
     ledThreshold = 500000;
     ledMinThreshold = 100000;

--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,5 @@
   ],
   "url": "https://github.com/biji/harddiskled",
   "uuid": "harddiskled@bijidroid.gmail.com",
-  "version": 35
+  "version": 36
 }


### PR DESCRIPTION
Updated the timeout mechanism from Mainloop.timeout_add_seconds to GLib.timeout_add to ensure compatibility with GNOME 45. The refresh time is now multiplied by 200 to convert it into milliseconds, aligning with GLib.timeout_add's requirements for precise timing. 