### PR TITLE
Mark compatible with GNOME Shell 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "name": "Harddisk LED",
   "settings-schema": "org.gnome.shell.extensions.harddiskled",
   "shell-version": [
-    "46"
+    "46", "47"
   ],
   "url": "https://github.com/biji/harddiskled",
   "uuid": "harddiskled@bijidroid.gmail.com",


### PR DESCRIPTION
GNOME 47 is scheduled for release on Wednesday.

I did a very simple smoketest with this change on Debian with gnome-shell 47.rc

See also https://gjs.guide/extensions/upgrading/gnome-shell-47.html